### PR TITLE
fix(docs): npm install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This loader will work best on Webpack 5 and likely 4 and node 12+. No guarantee 
 [npm][]:
 
 ```sh
-npm install -d simple-pug-loader
+npm install simple-pug-loader --save-dev
 ```
 
 [yarn][]:


### PR DESCRIPTION
`-d` is a different flag not related to dev dependency, the proper flag would be `-D`, but because of this confusion it's better not to use flag shorthands in instructions altogether.